### PR TITLE
CMParts - Battery light: 100% charged level (2/2)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -90,7 +90,8 @@
     <string name="battery_light_list_title">Colors</string>
     <string name="battery_light_low_color_title">Battery low</string>
     <string name="battery_light_medium_color_title">Charging</string>
-    <string name="battery_light_full_color_title">Fully charged</string>
+    <string name="battery_light_full_color_title">Charged (90%)</string>
+    <string name="battery_light_really_full_color_title">Charged (100%)</string>
 
     <!-- Lights settings screen, notification light settings -->
     <string name="notification_light_title">Notification light</string>

--- a/res/xml/battery_light_settings.xml
+++ b/res/xml/battery_light_settings.xml
@@ -55,6 +55,11 @@
             android:title="@string/battery_light_full_color_title"
             android:persistent="false" />
 
+        <org.cyanogenmod.cmparts.notificationlight.ApplicationLightPreference
+            android:key="really_full_color"
+            android:title="@string/battery_light_really_full_color_title"
+            android:persistent="false" />
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/src/org/cyanogenmod/cmparts/notificationlight/BatteryLightSettings.java
+++ b/src/org/cyanogenmod/cmparts/notificationlight/BatteryLightSettings.java
@@ -21,6 +21,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.provider.Settings;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceGroup;
 import android.support.v7.preference.PreferenceScreen;
@@ -41,6 +42,7 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
     private static final String LOW_COLOR_PREF = "low_color";
     private static final String MEDIUM_COLOR_PREF = "medium_color";
     private static final String FULL_COLOR_PREF = "full_color";
+    private static final String REALLY_FULL_COLOR_PREF = "really_full_color";
     private static final String LIGHT_ENABLED_PREF = "battery_light_enabled";
     private static final String PULSE_ENABLED_PREF = "battery_light_pulse";
 
@@ -48,6 +50,7 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
     private ApplicationLightPreference mLowColorPref;
     private ApplicationLightPreference mMediumColorPref;
     private ApplicationLightPreference mFullColorPref;
+    private ApplicationLightPreference mReallyFullColorPref;
     private CMSystemSettingSwitchPreference mLightEnabledPref;
     private CMSystemSettingSwitchPreference mPulseEnabledPref;
 
@@ -87,6 +90,9 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
 
             mFullColorPref = (ApplicationLightPreference) prefSet.findPreference(FULL_COLOR_PREF);
             mFullColorPref.setOnPreferenceChangeListener(this);
+
+            mReallyFullColorPref = (ApplicationLightPreference) prefSet.findPreference(REALLY_FULL_COLOR_PREF);
+            mReallyFullColorPref.setOnPreferenceChangeListener(this);
         } else {
             prefSet.removePreference(prefSet.findPreference("colors_list"));
             resetColors();
@@ -122,6 +128,12 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
                     res.getInteger(com.android.internal.R.integer.config_notificationsBatteryFullARGB));
             mFullColorPref.setAllValues(fullColor, 0, 0, false);
         }
+
+        if (mReallyFullColorPref != null) {
+            int reallyFullColor = Settings.System.getInt(resolver, Settings.System.BATTERY_LIGHT_REALLY_FULL_COLOR,
+                    res.getInteger(com.android.internal.R.integer.config_notificationsBatteryFullARGB));
+            mReallyFullColorPref.setAllValues(reallyFullColor, 0, 0, false);
+        }
     }
 
     /**
@@ -139,6 +151,8 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
             CMSettings.System.putInt(resolver, CMSettings.System.BATTERY_LIGHT_MEDIUM_COLOR, color);
         } else if (key.equals(FULL_COLOR_PREF)) {
             CMSettings.System.putInt(resolver, CMSettings.System.BATTERY_LIGHT_FULL_COLOR, color);
+        } else if (key.equals(REALLY_FULL_COLOR_PREF)) {
+            Settings.System.putInt(resolver, Settings.System.BATTERY_LIGHT_REALLY_FULL_COLOR, color);
         }
     }
 
@@ -175,6 +189,8 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
                 res.getInteger(com.android.internal.R.integer.config_notificationsBatteryMediumARGB));
         CMSettings.System.putInt(resolver, CMSettings.System.BATTERY_LIGHT_FULL_COLOR,
                 res.getInteger(com.android.internal.R.integer.config_notificationsBatteryFullARGB));
+        Settings.System.putInt(resolver, Settings.System.BATTERY_LIGHT_REALLY_FULL_COLOR,
+                res.getInteger(com.android.internal.R.integer.config_notificationsBatteryReallyFullARGB));
         refreshDefault();
     }
 


### PR DESCRIPTION
Change-Id: I06718c404acf7b24aeec47d8dca6b17571c8a704
Signed-off-by: Pafcholini <nadyaivanova14@gmail.com>